### PR TITLE
Fix KeyError: 'status' in youtube_update_video when privacy_status is omitted

### DIFF
--- a/src/youtube_mcp/tools/publishing.py
+++ b/src/youtube_mcp/tools/publishing.py
@@ -127,10 +127,14 @@ def youtube_update_video(
     quota.consume("update")
     response = youtube.videos().update(part=parts, body=body).execute()
 
+    # part='snippet' responses omit the 'status' block entirely, so access it
+    # defensively. Only surface the privacy field when the server actually
+    # returned it.
+    response_status = response.get("status") or {}
     return {
         "id": response["id"],
         "title": response["snippet"]["title"],
-        "privacy": response["status"]["privacyStatus"],
+        "privacy": response_status.get("privacyStatus"),
         "updated": True,
     }
 

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -89,6 +89,46 @@ class TestUpdateVideo:
         result = youtube_update_video(video_id="nope", title="X")
         assert "error" in result
 
+    @patch("youtube_mcp.tools.publishing.auth")
+    @patch("youtube_mcp.tools.publishing.quota")
+    def test_update_without_privacy_status_does_not_raise_keyerror(
+        self, mock_quota, mock_auth
+    ):
+        """Regression: when privacy_status is not provided, part='snippet' is sent
+        and the YouTube API response omits the 'status' field. The function must
+        not raise KeyError when parsing the response.
+        """
+        from youtube_mcp.tools.publishing import youtube_update_video
+
+        mock_yt = MagicMock()
+        mock_auth.build_youtube_service.return_value = mock_yt
+
+        mock_yt.videos().list().execute.return_value = {
+            "items": [{
+                "id": "vid1",
+                "snippet": {
+                    "title": "Old Title",
+                    "description": "Desc",
+                    "tags": ["tag1"],
+                    "categoryId": "22",
+                },
+                "status": {"privacyStatus": "public"},
+            }]
+        }
+
+        mock_yt.videos().update().execute.return_value = {
+            "kind": "youtube#video",
+            "etag": "abc",
+            "id": "vid1",
+            "snippet": {"title": "New Title"},
+        }
+
+        result = youtube_update_video(video_id="vid1", title="New Title")
+        assert result["id"] == "vid1"
+        assert result["title"] == "New Title"
+        assert result["updated"] is True
+        assert result.get("privacy") is None
+
 
 class TestSetThumbnail:
     @patch("youtube_mcp.tools.publishing.MediaFileUpload")


### PR DESCRIPTION
Fixes #2

## Summary

When `youtube_update_video` is called without `privacy_status`, `parts` is `"snippet"` only, so the YouTube API response has no `status` block. The existing return builder unconditionally reads `response["status"]["privacyStatus"]` and raises `KeyError: 'status'` — even though the update on YouTube itself succeeded.

## Change

- Access the `status` block defensively via `.get("status") or {}` and return `privacy=None` when the server did not send it back.
- No change to the call shape: `privacy_status` in, `privacy` out stays the same when the server returns `status`.

## Regression test

`tests/test_publishing.py::TestUpdateVideo::test_update_without_privacy_status_does_not_raise_keyerror` reproduces the bug by mocking a realistic `part=snippet`-only response and asserts that the tool returns cleanly with `privacy=None`.

Before the fix the test fails with `KeyError: 'status'`; after the fix all 75 tests pass.

## Verification

```
uv venv && uv pip install -e ".[dev]"
.venv/bin/python -m pytest tests/ -v
# 75 passed
```

No changes to public API shape, no new dependencies.
