### PR TITLE
Add youtube.force-ssl scope and validate cached token scopes

### DIFF
--- a/src/youtube_mcp/auth.py
+++ b/src/youtube_mcp/auth.py
@@ -13,11 +13,15 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
-# All scopes we need across all phases
+# All scopes we need across all phases.
+# youtube.force-ssl is required by commentThreads.insert / comments.insert;
+# without it, youtube_post_comment and youtube_reply_to_comment fail with
+# 403 insufficientPermissions.
 SCOPES = [
     "https://www.googleapis.com/auth/youtube.readonly",
     "https://www.googleapis.com/auth/youtube",
     "https://www.googleapis.com/auth/youtube.upload",
+    "https://www.googleapis.com/auth/youtube.force-ssl",
     "https://www.googleapis.com/auth/yt-analytics.readonly",
     "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
 ]
@@ -71,6 +75,28 @@ class YouTubeAuth:
         self.config_dir.mkdir(parents=True, exist_ok=True)
         self.token_path.write_text(creds.to_json())
 
+    @staticmethod
+    def _has_required_scopes(creds: Credentials | None) -> bool:
+        """Return True if the cached credential covers every scope in SCOPES.
+
+        google-auth's `creds.valid` only reflects token expiry, not scope
+        coverage. When SCOPES is expanded (e.g. adding youtube.force-ssl for
+        comment posting), a previously saved token still reports valid but
+        will 403 on any newly-required API. We must detect the mismatch and
+        drop back to the OAuth flow.
+        """
+        if creds is None:
+            return False
+        granted = set(creds.scopes or [])
+        return set(SCOPES).issubset(granted)
+
+    def _invalidate_token_file(self):
+        """Remove stale token so a fresh OAuth flow can overwrite it."""
+        try:
+            self.token_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
     def authenticate(self) -> Credentials:
         """Get valid credentials, running OAuth flow if needed.
 
@@ -79,19 +105,24 @@ class YouTubeAuth:
         """
         creds = self._load_token()
 
-        if creds and creds.valid:
+        if creds and creds.valid and self._has_required_scopes(creds):
             self._credentials = creds
             return creds
 
-        if creds and creds.expired and creds.refresh_token:
+        if creds and creds.expired and creds.refresh_token and self._has_required_scopes(creds):
             try:
                 creds.refresh(Request())
                 self._save_token(creds)
                 self._credentials = creds
                 return creds
-            except Exception as e:
+            except Exception:
                 # Refresh failed, need to re-auth
                 pass
+
+        # Either no token, expired without refresh, or scopes insufficient.
+        # Drop the stale token so we do not keep reusing it.
+        if creds is not None and not self._has_required_scopes(creds):
+            self._invalidate_token_file()
 
         # Need to run the OAuth flow
         if not self.client_secret_path.exists():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from youtube_mcp.auth import AuthError, YouTubeAuth
+from youtube_mcp.auth import SCOPES, AuthError, YouTubeAuth
 
 
 def test_default_config_dir():
@@ -86,3 +86,58 @@ def test_load_and_save_token(tmp_path):
 
     yt_auth._save_token(mock_creds)
     assert (tmp_path / "token.json").exists()
+
+
+def test_scopes_include_force_ssl_for_comment_writes():
+    """commentThreads.insert and comments.insert require youtube.force-ssl.
+    Without this scope, write calls fail with 403 insufficientPermissions.
+    """
+    assert "https://www.googleapis.com/auth/youtube.force-ssl" in SCOPES
+
+
+class TestCachedTokenScopeValidation:
+    """Regression: when SCOPES is expanded (e.g. adding youtube.force-ssl),
+    existing cached tokens authorize only the old scope set but still report
+    creds.valid == True. authenticate() must detect the scope shortfall and
+    fall back to the interactive flow instead of returning stale credentials.
+    """
+
+    @patch("youtube_mcp.auth.Credentials.from_authorized_user_file")
+    def test_cached_token_missing_scopes_triggers_reauth(
+        self, mock_from_file, tmp_path
+    ):
+        insufficient_creds = MagicMock()
+        insufficient_creds.valid = True
+        insufficient_creds.expired = False
+        insufficient_creds.scopes = [
+            "https://www.googleapis.com/auth/youtube.readonly",
+        ]
+        mock_from_file.return_value = insufficient_creds
+
+        (tmp_path / "token.json").write_text("{}")
+
+        yt_auth = YouTubeAuth(
+            config_dir=tmp_path,
+            client_secret_path=tmp_path / "nonexistent.json",
+        )
+
+        # With no client_secret available, a forced re-auth surfaces as
+        # AuthError. That proves we did not silently return the stale creds.
+        with pytest.raises(AuthError, match="client_secret.json not found"):
+            yt_auth.authenticate()
+
+    @patch("youtube_mcp.auth.Credentials.from_authorized_user_file")
+    def test_cached_token_with_all_scopes_is_accepted(
+        self, mock_from_file, tmp_path
+    ):
+        sufficient_creds = MagicMock()
+        sufficient_creds.valid = True
+        sufficient_creds.expired = False
+        sufficient_creds.scopes = list(SCOPES)
+        mock_from_file.return_value = sufficient_creds
+
+        (tmp_path / "token.json").write_text("{}")
+
+        yt_auth = YouTubeAuth(config_dir=tmp_path)
+        result = yt_auth.authenticate()
+        assert result is sufficient_creds


### PR DESCRIPTION
Fixes #3

## Summary

Two related regressions make `youtube_post_comment` and `youtube_reply_to_comment` fail with `403 insufficientPermissions`:

1. `SCOPES` is missing `https://www.googleapis.com/auth/youtube.force-ssl`, which `commentThreads.insert` and `comments.insert` require.
2. `authenticate()` trusts `creds.valid` from the cached `token.json` without checking that the cached scopes cover `SCOPES`, so any scope expansion silently reuses stale tokens.

## Change

- Add `https://www.googleapis.com/auth/youtube.force-ssl` to `SCOPES`.
- Add `_has_required_scopes(creds)` as a static helper and gate both the cached-reuse and refresh-token branches of `authenticate()` on it.
- Invalidate the stale `token.json` when the scope check fails so the next `authenticate()` writes a fresh one instead of looping on the old file.

No behavior change for users whose tokens already cover all scopes (freshly authenticated after this patch).

## Regression tests

- `test_scopes_include_force_ssl_for_comment_writes` — asserts the new scope is present.
- `TestCachedTokenScopeValidation::test_cached_token_missing_scopes_triggers_reauth` — mocks a cached creds with only `youtube.readonly` and no `client_secret.json`; previously `authenticate()` silently returned the stale creds, now it raises `AuthError` (proving the re-auth path was taken).
- `TestCachedTokenScopeValidation::test_cached_token_with_all_scopes_is_accepted` — ensures the happy path still returns the cached creds when scopes cover `SCOPES`.

## Verification

```
uv venv && uv pip install -e ".[dev]"
.venv/bin/python -m pytest tests/ -v
# 77 passed
```

No new dependencies. Users with stale tokens will see one extra browser OAuth consent on next use (the intended behavior).
