### PR TITLE
Add optional youtube.force-ssl scope for comment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Use `youtube_auth_status` to check current quota usage.
 | `YOUTUBE_MCP_CLIENT_SECRET` | Path to `client_secret.json` |
 | `YOUTUBE_MCP_CONFIG_DIR` | Config directory (default: `~/.youtube-mcp`) |
 | `YOUTUBE_API_KEY` | API key for public-only operations |
+| `YOUTUBE_MCP_ENABLE_COMMENTS` | Set to `1` to include the `youtube.force-ssl` scope, required for the comment tools (`youtube_list_comments`, `youtube_post_comment`, `youtube_reply_to_comment`). Off by default to keep the OAuth consent screen minimal. Re-run `youtube_auth` after enabling. |
 
 ## Development
 

--- a/src/youtube_mcp/auth.py
+++ b/src/youtube_mcp/auth.py
@@ -13,14 +13,31 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
-# All scopes we need across all phases
-SCOPES = [
+# Base scopes covering channel/video/playlist reads + writes, uploads,
+# and the two analytics APIs.
+_BASE_SCOPES = [
     "https://www.googleapis.com/auth/youtube.readonly",
     "https://www.googleapis.com/auth/youtube",
     "https://www.googleapis.com/auth/youtube.upload",
     "https://www.googleapis.com/auth/yt-analytics.readonly",
     "https://www.googleapis.com/auth/yt-analytics-monetary.readonly",
 ]
+
+# Required for the YouTube Data API's comment endpoints (commentThreads.list,
+# comments.insert, comments.update). Opt-in because it broadens the OAuth
+# consent screen — users who don't intend to read or post comments can leave
+# it off.
+_COMMENT_SCOPE = "https://www.googleapis.com/auth/youtube.force-ssl"
+
+
+def _resolve_scopes() -> list[str]:
+    scopes = list(_BASE_SCOPES)
+    if os.environ.get("YOUTUBE_MCP_ENABLE_COMMENTS", "").lower() in ("1", "true", "yes"):
+        scopes.append(_COMMENT_SCOPE)
+    return scopes
+
+
+SCOPES = _resolve_scopes()
 
 DEFAULT_CONFIG_DIR = Path.home() / ".youtube-mcp"
 TOKEN_FILE = "token.json"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from youtube_mcp.auth import AuthError, YouTubeAuth
+from youtube_mcp.auth import AuthError, YouTubeAuth, _resolve_scopes
 
 
 def test_default_config_dir():
@@ -70,6 +70,25 @@ def test_build_public_youtube_service_no_key(tmp_path):
         yt_auth.api_key = None
         with pytest.raises(AuthError, match="No API key available"):
             yt_auth.build_public_youtube_service()
+
+
+def test_resolve_scopes_excludes_force_ssl_by_default(monkeypatch):
+    monkeypatch.delenv("YOUTUBE_MCP_ENABLE_COMMENTS", raising=False)
+    scopes = _resolve_scopes()
+    assert "https://www.googleapis.com/auth/youtube.force-ssl" not in scopes
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes"])
+def test_resolve_scopes_includes_force_ssl_when_enabled(monkeypatch, value):
+    monkeypatch.setenv("YOUTUBE_MCP_ENABLE_COMMENTS", value)
+    scopes = _resolve_scopes()
+    assert "https://www.googleapis.com/auth/youtube.force-ssl" in scopes
+
+
+def test_resolve_scopes_ignores_unrecognised_value(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_MCP_ENABLE_COMMENTS", "maybe")
+    scopes = _resolve_scopes()
+    assert "https://www.googleapis.com/auth/youtube.force-ssl" not in scopes
 
 
 def test_load_and_save_token(tmp_path):


### PR DESCRIPTION
## Summary

The comment tools (`youtube_list_comments`, `youtube_post_comment`, `youtube_reply_to_comment`) currently fail with HTTP 403 *Insufficient Permission* because the YouTube Data API requires the `https://www.googleapis.com/auth/youtube.force-ssl` scope for every `commentThreads` / `comments` endpoint, and that scope isn't requested anywhere in `auth.py`.

This PR adds it conditionally via a new env var:

- `YOUTUBE_MCP_ENABLE_COMMENTS=1` (also `true` / `yes`) → `youtube.force-ssl` is appended to the OAuth scopes
- Unset / `0` / `false` / anything else → behaviour is identical to today

Default is **off** to keep the OAuth consent screen minimal for users who only want analytics/upload/playlists. Users who want to manage comments opt in with one env var and re-run `youtube_auth`.

## Why opt-in rather than always on?

`youtube.force-ssl` is the broadest of the YouTube Data scopes (it grants full read/write across the channel, including comments), and the consent screen labels it accordingly. Users who never touch the comment tools — analytics consumers, upload automations, playlist managers — shouldn't have to grant it. Making it explicit also makes the scope auditable from the registered MCP config.

## Repro of the underlying bug

With the current `main` and an authenticated token:

\`\`\`
$ # any comment tool, e.g. youtube_list_comments
HttpError 403: \"Request had insufficient authentication scopes.\"
\`\`\`

After setting \`YOUTUBE_MCP_ENABLE_COMMENTS=1\` and re-running \`youtube_auth\`, the same call returns the comment thread list as expected.

## Changes

- \`src/youtube_mcp/auth.py\` — split \`SCOPES\` into \`_BASE_SCOPES\` + an opt-in \`_COMMENT_SCOPE\`, resolved at import time via \`_resolve_scopes()\`. The exported \`SCOPES\` constant is preserved so existing call sites (\`_load_token\`, \`authenticate\`) are unchanged.
- \`tests/test_auth.py\` — adds 7 new test cases (default-off, parametrised truthy values, ignored-bad-value, baseline) covering the toggle.
- \`README.md\` — documents the new env var in the Environment Variables table.

## Test plan

- [x] \`pytest tests/test_auth.py\` — 17/17 pass locally (Python 3.14)
- [x] Manual: with the env var set and a re-issued token, \`youtube_list_comments\` succeeds against a real channel where it previously 403'd
- [x] Manual: without the env var set, an existing token continues to load and refresh without prompting for re-consent

## Backward compatibility

- Existing tokens (without \`force-ssl\`) keep working — they don't request the new scope unless the env var is set.
- The \`SCOPES\` module-level constant is preserved (still a list of strings), in case any downstream code imports it.
- No changes to tool signatures, MCP entry point, or installation path.